### PR TITLE
Visual Studio 2013 Fix

### DIFF
--- a/include/SWCP.h
+++ b/include/SWCP.h
@@ -6,6 +6,10 @@
 #include <sstream>
 #include <map>
 
+#ifdef VS2013
+	#include <stdint.h>
+#endif
+
 namespace SWCP 
 {
 	#if __cplusplus >= 201103L

--- a/include/SWCP.h
+++ b/include/SWCP.h
@@ -73,7 +73,7 @@ namespace SWCP
 			Custom,
 		};
 
-		Vertex(int64_t id, Type type, double x, double y, double z, float radius) : id(id), type(type), radius(radius), x(x), y(y), z(z)
+		Vertex(int64_t id, Type type, double x, double y, double z, float radius) : id(id), type(type), radius(radius), x(x), y(y), z(z), visited(false)
 		{};
 
 		int64_t id;
@@ -82,6 +82,7 @@ namespace SWCP
 		double z;
 		float radius;
 		Type type;
+		bool visited;
 	};
 		
 	struct Edge
@@ -95,6 +96,7 @@ namespace SWCP
 	
 	struct Graph
 	{
+		std::vector<int64_t> rootIDs;
 		std::vector<Vertex> vertices;
 		std::vector<Edge> edges;
 		std::vector<std::string> meta;
@@ -287,6 +289,10 @@ namespace SWCP
 									if (parent != -1)
 									{
 										graph.edges.push_back(Edge(parent, id));
+									}
+									else
+									{
+										graph.rootIDs.push_back(id);
 									}
 									return true;
 								}

--- a/include/SWCP.h
+++ b/include/SWCP.h
@@ -17,7 +17,7 @@ namespace SWCP
 
 	// If not c++11 and if it is not version of MSVC that is c++11 compatible, 
 	// then define own int64_t and uint64_t types in SWCP namespace.
-	#if !defined SWCP_CPP11_COMPATIBLE
+	#if !defined SWCP_CPP11_COMPATIBLE && !defined SWIG
 		typedef long long int int64_t;
 		typedef unsigned long long int uint64_t;
 	#endif
@@ -495,6 +495,11 @@ namespace SWCP
 		bool result = Write(sstream, graph);
 		outString = sstream.str();
 		return result;
+	}
+
+	inline std::string Generator::GetErrorMessage()
+	{
+		return m_errorMessage.str();
 	}
 
 	inline bool Generator::WriteToFile(const char *filename, const Graph& graph)


### PR DESCRIPTION
Adds additional include required for compilation in Visual Studio 2013. Included only in this case, via preprocessor. 